### PR TITLE
Replace qemu-img with dog for sheepdog 0.9.0 compatibility

### DIFF
--- a/src/datastore_mad/remotes/sheepdog/clone
+++ b/src/datastore_mad/remotes/sheepdog/clone
@@ -68,7 +68,16 @@ SAFE_DIRS=""
 IMAGE_NAME="one-${ID}"
 SHEEPDOG_DST="${IMAGE_NAME}"
 
-ssh_exec_and_log "$DST_HOST" "$QEMU_IMG snapshot -c source_snap_$ID sheepdog:$SRC && $QEMU_IMG create -b sheepdog:$SRC:source_snap_$ID sheepdog:$SHEEPDOG_DST && sudo $DOG vdi delete -s source_snap_$ID $SRC" \
+DUMP_CMD=$(cat <<EOF
+set -e
+
+sudo $DOG vdi snapshot -s source_snap_$ID $SRC
+sudo $DOG vdi clone -s source_snap_$ID $SRC $SHEEPDOG_DST
+sudo $DOG vdi delete -s source_snap_$ID $SRC
+
+EOF
+)
+ssh_exec_and_log "$DST_HOST" "$DUMP_CMD" \
                 "Error cloning $SRC to $SHEEPDOG_DST in $DST_HOST"
 
 echo "$SHEEPDOG_DST"

--- a/src/tm_mad/sheepdog/clone
+++ b/src/tm_mad/sheepdog/clone
@@ -59,11 +59,17 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VM_ID| $XPATH \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/BRIDGE_LIST \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
+BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
 if [ -n "$SHEEPDOG_HOST" ]; then
-    DST_HOST=$SHEEPDOG_HOST
+    DST_HOST=`get_destination_host`
+    if [ -z "$DST_HOST" ]; then
+        error_message "Datastore template missing 'BRIDGE_LIST' attribute."
+        exit -1
+    fi
 fi
 
 #-------------------------------------------------------------------------------
@@ -74,7 +80,7 @@ CLONE_CMD=$(cat <<EOF
 set -e
 
 sudo $DOG vdi snapshot -s $SHEEPDOG_SNAP $SRC_PATH
-sudo $DOG vdi clone -s $SHEEPDOG_SNAP $SHEEPDOG_PATH $SHEEPDOG_DST
+sudo $DOG vdi clone -s $SHEEPDOG_SNAP $SRC_PATH $SHEEPDOG_DST
 sudo $DOG vdi delete -s $SHEEPDOG_SNAP $SRC_PATH
 
 EOF

--- a/src/tm_mad/sheepdog/clone
+++ b/src/tm_mad/sheepdog/clone
@@ -54,6 +54,18 @@ SHEEPDOG_SNAP="$( basename $0 )_${VM_ID}-${DISK_ID}"
 
 XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
 
+unset i j XPATH_ELEMENTS
+
+while IFS= read -r -d '' element; do
+    XPATH_ELEMENTS[i++]="$element"
+done < <(onevm show -x $VM_ID| $XPATH \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
+
+SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
+if [ -n "$SHEEPDOG_HOST" ]; then
+    DST_HOST=$SHEEPDOG_HOST
+fi
+
 #-------------------------------------------------------------------------------
 # Clone the image
 #-------------------------------------------------------------------------------
@@ -61,8 +73,8 @@ XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
 CLONE_CMD=$(cat <<EOF
 set -e
 
-$QEMU_IMG snapshot -c $SHEEPDOG_SNAP sheepdog:$SRC_PATH
-$QEMU_IMG create -b sheepdog:$SRC_PATH:$SHEEPDOG_SNAP sheepdog:$SHEEPDOG_DST
+sudo $DOG vdi snapshot -s $SHEEPDOG_SNAP $SRC_PATH
+sudo $DOG vdi clone -s $SHEEPDOG_SNAP $SHEEPDOG_PATH $SHEEPDOG_DST
 sudo $DOG vdi delete -s $SHEEPDOG_SNAP $SRC_PATH
 
 EOF

--- a/src/tm_mad/sheepdog/clone
+++ b/src/tm_mad/sheepdog/clone
@@ -59,17 +59,11 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VM_ID| $XPATH \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/BRIDGE_LIST \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
-BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
-if [ -n "$SHEEPDOG_HOST" ]; then
-    DST_HOST=`get_destination_host`
-    if [ -z "$DST_HOST" ]; then
-        error_message "Datastore template missing 'BRIDGE_LIST' attribute."
-        exit -1
-    fi
+if [ -z "$SHEEPDOG_HOST" ]; then
+    SHEEPDOG_HOST="127.0.0.1"
 fi
 
 #-------------------------------------------------------------------------------
@@ -79,9 +73,9 @@ fi
 CLONE_CMD=$(cat <<EOF
 set -e
 
-sudo $DOG vdi snapshot -s $SHEEPDOG_SNAP $SRC_PATH
-sudo $DOG vdi clone -s $SHEEPDOG_SNAP $SRC_PATH $SHEEPDOG_DST
-sudo $DOG vdi delete -s $SHEEPDOG_SNAP $SRC_PATH
+sudo $DOG vdi snapshot -a $SHEEPDOG_HOST -s $SHEEPDOG_SNAP $SRC_PATH
+sudo $DOG vdi clone -a $SHEEPDOG_HOST -s $SHEEPDOG_SNAP $SRC_PATH $SHEEPDOG_DST
+sudo $DOG vdi delete -a $SHEEPDOG_HOST -s $SHEEPDOG_SNAP $SRC_PATH
 
 EOF
 )

--- a/src/tm_mad/sheepdog/cpds
+++ b/src/tm_mad/sheepdog/cpds
@@ -59,10 +59,15 @@ while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VM_ID| $XPATH \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT)
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
 SRC="${XPATH_ELEMENTS[j++]}"
 PERSISTENT="${XPATH_ELEMENTS[j++]}"
+SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
+if [ -n "$SHEEPDOG_HOST" ]; then
+    SRC_HOST=$SHEEPDOG_HOST
+fi
 
 SHEEPDOG_SRC=`arg_path $SRC`
 SHEEPDOG_DST="${DST}"
@@ -71,8 +76,8 @@ SHEEPDOG_SNAP="$( basename $0 )_${VM_ID}-${DISK_ID}"
 COPY_CMD="$(cat <<EOF
 set -e
 
-$QEMU_IMG snapshot -c $SHEEPDOG_SNAP sheepdog:$SHEEPDOG_SRC
-$QEMU_IMG create -b sheepdog:$SHEEPDOG_SRC:$SHEEPDOG_SNAP sheepdog:$SHEEPDOG_DST
+sudo $DOG vdi snapshot -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
+sudo $DOG vdi clone -s $SHEEPDOG_SNAP $SHEEPDOG_SRC $SHEEPDOG_DST
 sudo $DOG vdi delete -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
 
 EOF

--- a/src/tm_mad/sheepdog/cpds
+++ b/src/tm_mad/sheepdog/cpds
@@ -60,13 +60,19 @@ while IFS= read -r -d '' element; do
 done < <(onevm show -x $VM_ID| $XPATH \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/BRIDGE_LIST \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
 SRC="${XPATH_ELEMENTS[j++]}"
 PERSISTENT="${XPATH_ELEMENTS[j++]}"
+BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
 if [ -n "$SHEEPDOG_HOST" ]; then
-    SRC_HOST=$SHEEPDOG_HOST
+    SRC_HOST=`get_destination_host`
+    if [ -z "$SRC_HOST" ]; then
+        error_message "Datastore template missing 'BRIDGE_LIST' attribute."
+        exit -1
+    fi
 fi
 
 SHEEPDOG_SRC=`arg_path $SRC`

--- a/src/tm_mad/sheepdog/cpds
+++ b/src/tm_mad/sheepdog/cpds
@@ -60,19 +60,13 @@ while IFS= read -r -d '' element; do
 done < <(onevm show -x $VM_ID| $XPATH \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/BRIDGE_LIST \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
 SRC="${XPATH_ELEMENTS[j++]}"
 PERSISTENT="${XPATH_ELEMENTS[j++]}"
-BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
-if [ -n "$SHEEPDOG_HOST" ]; then
-    SRC_HOST=`get_destination_host`
-    if [ -z "$SRC_HOST" ]; then
-        error_message "Datastore template missing 'BRIDGE_LIST' attribute."
-        exit -1
-    fi
+if [ -z "$SHEEPDOG_HOST" ]; then
+    SHEEPDOG_HOST="127.0.0.1"
 fi
 
 SHEEPDOG_SRC=`arg_path $SRC`
@@ -82,9 +76,9 @@ SHEEPDOG_SNAP="$( basename $0 )_${VM_ID}-${DISK_ID}"
 COPY_CMD="$(cat <<EOF
 set -e
 
-sudo $DOG vdi snapshot -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
-sudo $DOG vdi clone -s $SHEEPDOG_SNAP $SHEEPDOG_SRC $SHEEPDOG_DST
-sudo $DOG vdi delete -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
+sudo $DOG vdi snapshot -a $SHEEPDOG_HOST -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
+sudo $DOG vdi clone -a $SHEEPDOG_HOST -s $SHEEPDOG_SNAP $SHEEPDOG_SRC $SHEEPDOG_DST
+sudo $DOG vdi delete -a $SHEEPDOG_HOST -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
 
 EOF
 )"

--- a/src/tm_mad/sheepdog/delete
+++ b/src/tm_mad/sheepdog/delete
@@ -69,14 +69,20 @@ done < <(onevm show -x $VM_ID| $XPATH \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT \
 		    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/BRIDGE_LIST \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
 SRC="${XPATH_ELEMENTS[j++]}"
 PERSISTENT="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
+BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
 if [ -n "$SHEEPDOG_HOST" ]; then
-    DST_HOST=$SHEEPDOG_HOST
+    DST_HOST=`get_destination_host`
+    if [ -z "$DST_HOST" ]; then
+        error_message "Datastore template missing 'BRIDGE_LIST' attribute."
+        exit -1
+    fi
 fi
 
 # Exit if persistent

--- a/src/tm_mad/sheepdog/delete
+++ b/src/tm_mad/sheepdog/delete
@@ -68,11 +68,16 @@ while IFS= read -r -d '' element; do
 done < <(onevm show -x $VM_ID| $XPATH \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT \
-		    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE ) 
+		    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
 SRC="${XPATH_ELEMENTS[j++]}"
 PERSISTENT="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
+SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
+if [ -n "$SHEEPDOG_HOST" ]; then
+    DST_HOST=$SHEEPDOG_HOST
+fi
 
 # Exit if persistent
 [ -n "$PERSISTENT" ] && log "Disk $DISK_ID is persistent - not deleting" && exit 0

--- a/src/tm_mad/sheepdog/delete
+++ b/src/tm_mad/sheepdog/delete
@@ -69,20 +69,14 @@ done < <(onevm show -x $VM_ID| $XPATH \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT \
 		    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/BRIDGE_LIST \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
 SRC="${XPATH_ELEMENTS[j++]}"
 PERSISTENT="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
-BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
-if [ -n "$SHEEPDOG_HOST" ]; then
-    DST_HOST=`get_destination_host`
-    if [ -z "$DST_HOST" ]; then
-        error_message "Datastore template missing 'BRIDGE_LIST' attribute."
-        exit -1
-    fi
+if [ -z "$SHEEPDOG_HOST" ]; then
+    SHEEPDOG_HOST="127.0.0.1"
 fi
 
 # Exit if persistent
@@ -107,7 +101,7 @@ log "Deleting $DST_PATH"
 DELETE_CMD=$(cat <<EOF
 set -e
 
-sudo $DOG vdi delete $SHEEPDOG_SRC
+sudo $DOG vdi delete -a $SHEEPDOG_HOST $SHEEPDOG_SRC
 
 EOF
 )

--- a/src/tm_mad/sheepdog/mvds
+++ b/src/tm_mad/sheepdog/mvds
@@ -60,19 +60,14 @@ while IFS= read -r -d '' element; do
 done < <(onevm show -x $VM_ID| $XPATH \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/BRIDGE_LIST \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
 SHEEPDOG_SRC="${XPATH_ELEMENTS[j++]}"
 PERSISTENT="${XPATH_ELEMENTS[j++]}"
 BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
-if [ -n "$SHEEPDOG_HOST" ]; then
-    SRC_HOST=`get_destination_host`
-    if [ -z "$SRC_HOST" ]; then
-        error_message "Datastore template missing 'BRIDGE_LIST' attribute."
-        exit -1
-    fi
+if [ -z "$SHEEPDOG_HOST" ]; then
+    SHEEPDOG_HOST="127.0.0.1"
 fi
 
 # Exit if persistent
@@ -90,10 +85,10 @@ log "Dumping $SHEEPDOG_SRC to $DST"
 DUMP_CMD=$(cat <<EOF
 set -e
 
-sudo $DOG vdi snapshot -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
-sudo $DOG vdi clone -s $SHEEPDOG_SNAP $SHEEPDOG_SRC $SHEEPDOG_DST
-sudo $DOG vdi delete -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
-sudo $DOG vdi delete $SHEEPDOG_SRC
+sudo $DOG vdi snapshot -a $SHEEPDOG_HOST -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
+sudo $DOG vdi clone -a $SHEEPDOG_HOST -s $SHEEPDOG_SNAP $SHEEPDOG_SRC $SHEEPDOG_DST
+sudo $DOG vdi delete -a $SHEEPDOG_HOST -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
+sudo $DOG vdi delete -a $SHEEPDOG_HOST $SHEEPDOG_SRC
 
 EOF
 )

--- a/src/tm_mad/sheepdog/mvds
+++ b/src/tm_mad/sheepdog/mvds
@@ -59,11 +59,15 @@ while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VM_ID| $XPATH \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT )
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
 SHEEPDOG_SRC="${XPATH_ELEMENTS[j++]}"
 PERSISTENT="${XPATH_ELEMENTS[j++]}"
-
+SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
+if [ -n "$SHEEPDOG_HOST" ]; then
+    SRC_HOST=$SHEEPDOG_HOST
+fi
 # Exit if persistent
 [ -n "$PERSISTENT" ] && exit 0
 
@@ -79,8 +83,8 @@ log "Dumping $SHEEPDOG_SRC to $DST"
 DUMP_CMD=$(cat <<EOF
 set -e
 
-$QEMU_IMG snapshot -c $SHEEPDOG_SNAP sheepdog:$SHEEPDOG_SRC
-$QEMU_IMG create -b sheepdog:$SHEEPDOG_SRC:$SHEEPDOG_SNAP sheepdog:$DST 
+sudo $DOG vdi snapshot -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
+sudo $DOG vdi clone -s $SHEEPDOG_SNAP $SHEEPDOG_SRC $SHEEPDOG_DST
 sudo $DOG vdi delete -s $SHEEPDOG_SNAP $SHEEPDOG_SRC
 sudo $DOG vdi delete $SHEEPDOG_SRC
 

--- a/src/tm_mad/sheepdog/mvds
+++ b/src/tm_mad/sheepdog/mvds
@@ -60,14 +60,21 @@ while IFS= read -r -d '' element; do
 done < <(onevm show -x $VM_ID| $XPATH \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/BRIDGE_LIST \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SHEEPDOG_HOST)
 
 SHEEPDOG_SRC="${XPATH_ELEMENTS[j++]}"
 PERSISTENT="${XPATH_ELEMENTS[j++]}"
+BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 SHEEPDOG_HOST="${XPATH_ELEMENTS[j++]}"
 if [ -n "$SHEEPDOG_HOST" ]; then
-    SRC_HOST=$SHEEPDOG_HOST
+    SRC_HOST=`get_destination_host`
+    if [ -z "$SRC_HOST" ]; then
+        error_message "Datastore template missing 'BRIDGE_LIST' attribute."
+        exit -1
+    fi
 fi
+
 # Exit if persistent
 [ -n "$PERSISTENT" ] && exit 0
 


### PR DESCRIPTION
Sheepdog 0.9.0 do not allow opening single VDI by multiple QEMU process. 
I'm replace 'qemu-img' with 'dog' in all tm_mad/sheepdog scripts to avoid this. Also try to start ssh commands on SHEEPDOG_HOST node, if it defined.
